### PR TITLE
Introduce state selector function instead plain reference

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -18,30 +18,29 @@ const counterStore = createStore({
   actions: {
     increment: (state, count) => {
       console.log("Incrementing by", count);
-
-      return { ...state, counter: state.counter + count };
+      return { ...state(), counter: state().counter + count };
     },
 
     decrement: (state, count) => {
-      return { ...state, counter: state.counter - count };
+      return { ...state(), counter: state().counter - count };
     },
 
     reset: (state) => {
-      return { ...state, counter: 0 };
+      return { ...state(), counter: 0 };
     },
 
     toggleLoader: (state) => {
-      return { ...state, showLoader: !state.showLoader };
+      return { ...state(), showLoader: !state().showLoader };
     },
 
     asyncIncrement: async (state) => {
-      const amount = await getRandomAmout();
+      const amount = await getRandomAmout(2000);
       console.log("async inc by", amount);
-      return { ...state, counter: counterStore.getState().counter + amount };
+      return { ...state(), counter: counterStore.getState().counter + amount };
     },
 
     asyncDecrement: (state) => {
-      return Promise.resolve({ ...state, counter: state.counter - 5 });
+      return Promise.resolve({ ...state(), counter: state().counter - 5 });
     },
 
     deepUpdate: selector("state.deep.nested.value", (value, emoji) => {
@@ -52,8 +51,9 @@ const counterStore = createStore({
       "state.deep.nested.value",
       async (value, emoji) => {
         console.log("Waiting");
-        await wait(1000);
-        return value === "🤯" ? emoji : "🤯";
+        await wait(2000);
+        return "🎁";
+        // return value === "🤯" ? emoji : "🤯";
       }
     ),
   },
@@ -113,11 +113,11 @@ const cancelDeepSub = counterStore.on("deepUpdate", (state) =>
   console.log("DEEP", state.deep.nested.value)
 );
 
-function getRandomAmout() {
+function getRandomAmout(delay = 1000) {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve(Math.floor(Math.random() * 10));
-    }, 1000);
+    }, delay);
   });
 }
 

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -12,21 +12,21 @@ const store = createStore({
   },
   actions: {
     hello(state, text: string) {
-      return { ...state, text };
+      return { ...state(), text };
     },
 
     increment(state, amount: number) {
       return {
-        ...state,
-        count: state.count + amount,
+        ...state(),
+        count: state().count + amount,
       };
     },
 
     async asyncInc(state, amount: number) {
       const square = await Promise.resolve(amount * 2);
       return {
-        ...state,
-        count: state.count + square,
+        ...state(),
+        count: state().count + square,
       };
     },
 
@@ -40,16 +40,15 @@ const store = createStore({
   },
 });
 
-store.getState().count;
-store.getState((s) => s.text);
+store.state().count;
 store.decrement(2, "Hello, World!");
-store.decrement(2, "12");
+store.decrement(2, "Hello, World!");
 store.hello("Hello, World!");
 
 store.asyncInc(5);
 store.increment(5);
 
-store.getState().text;
+store.state().text;
 
 store.hello("Hello, World!");
 


### PR DESCRIPTION
# Main changes
- Change the "state" argument in actions to a getter function. This ensures the most recent state value is always retrieved, particularly in asynchronous actions that may take time to complete. During this period, another action might update the state, potentially causing it to become out of sync.
- Remove selector argument from getState(). There is no need for it.
- Change getState() to state() to make it consistent with action functions.
