### PR TITLE
API changes and better TS types

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -41,16 +41,16 @@ const store = createStore({
 });
 
 store.state().count;
-store.decrement(2, "Hello, World!");
-store.decrement(2, "Hello, World!");
-store.hello("Hello, World!");
+store.actions.decrement(2, "Hello, World!");
+store.actions.decrement(2, "Hello, World!");
+store.actions.hello("Hello, World!");
 
-store.asyncInc(5);
-store.increment(5);
+store.actions.asyncInc(5);
+store.actions.increment(5);
 
-store.state().text;
+store.state().count; // 5
 
-store.hello("Hello, World!");
+store.actions.hello("Hello, World!");
 
 store.on("hello", (state, action) => {
   console.log(`Hello action: "${action}" was called with text: ${state.text}`);

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,4 +1,5 @@
 import { createStore, selector } from "../src/index";
+import createStoreHooks from "../src/react";
 
 const store = createStore({
   state: {
@@ -55,3 +56,17 @@ store.actions.hello("Hello, World!");
 store.on("hello", (state, action) => {
   console.log(`Hello action: "${action}" was called with text: ${state.text}`);
 });
+
+const { useStore, useStoreActions, useStoreListeners } =
+  createStoreHooks(store);
+
+const [s, a] = useStore();
+s.deep;
+a.hello("Hello, World!");
+
+const ac = useStoreActions();
+ac.hello("Hello, hooks!");
+
+const on = useStoreListeners();
+
+on("decrement", () => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // MiniRDX by Wojciech Ludwin, @ludekarts
 
 // Store API action.
-type Action<S> = (state: () => S, ...args: any[]) => S | Promise<S>;
+export type Action<S> = (state: () => S, ...args: any[]) => S | Promise<S>;
 
 // Action listener decelared with "store.on()"" method.
 type ActionListener<S, A> = (state: S, actionName: keyof A) => void;
@@ -22,10 +22,19 @@ type OmitFirstParam<T extends (...args: any[]) => any> = T extends (
 
 const protectedKeys = ["on", "state", "actions"];
 
+export interface Store<S, A extends Record<string, Action<S>>> {
+  state: () => S;
+  actions: { [K in keyof A]: (...args: OmitFirstParam<A[K]>) => Promise<S> };
+  on: (
+    action: keyof A | ((state: S, actionName: keyof A) => void),
+    listener?: (state: S, actionName: keyof A) => void
+  ) => () => void;
+}
+
 export function createStore<S, A extends Record<string, Action<S>>>(config: {
   state: S;
   actions: A;
-}) {
+}): Store<S, A> {
   let { state, actions } = config;
   type Actions = typeof actions;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,13 @@ type Action<S> = (state: () => S, ...args: any[]) => S | Promise<S>;
 // Action listener decelared with "store.on()"" method.
 type ActionListener<S, A> = (state: S, actionName: keyof A) => void;
 
-// Internal collextion of all action listeners.
+// Internal collection of all action listeners.
 type ActionListenerColection<S, A> = Map<string, ActionListener<S, A>[]>;
 
 // Generic Promise resolve callback.
 type PromiseResolve<T> = (value: T) => void;
 
-// Allow to skip the first parameter of a function.
+// Allow to skip the first argument of a function.
 type OmitFirstParam<T extends (...args: any[]) => any> = T extends (
   state: any,
   ...args: infer P
@@ -20,7 +20,7 @@ type OmitFirstParam<T extends (...args: any[]) => any> = T extends (
   ? P
   : never;
 
-const protectedKeys = ["on", "state", "getState"];
+const protectedKeys = ["on", "state", "actions"];
 
 export function createStore<S, A extends Record<string, Action<S>>>(config: {
   state: S;
@@ -120,42 +120,40 @@ export function createStore<S, A extends Record<string, Action<S>>>(config: {
       globalListeners.forEach((listener) => listener(newState, "link"));
   }
 
+  // Subscribe to named and global actions.
+  function crereateListenr(
+    action: keyof Actions | ActionListener<S, A>,
+    listener?: ActionListener<S, A>
+  ) {
+    // Subscribe to global actions.
+    if (typeof action === "function" && listener === undefined) {
+      globalListeners.push(action);
+      return () => globalListeners.splice(globalListeners.indexOf(action), 1);
+    }
+
+    // Subscribe to specific actions.
+    else if (typeof action === "string" && listener) {
+      if (!actionListeners.has(action)) {
+        actionListeners.set(action, []);
+      }
+
+      actionListeners.get(action)?.push(listener);
+      return () => {
+        actionListeners
+          .get(action)
+          ?.splice(actionListeners.get(action)?.indexOf(listener) as number, 1);
+      };
+    } else {
+      throw new Error(
+        "MiniRdxError: Invalid arguments. Try: state.on(action: string, listener: ActionListener)"
+      );
+    }
+  }
+
   return {
     state: getState,
-
-    on(
-      action: keyof Actions | ActionListener<S, A>,
-      listener?: ActionListener<S, A>
-    ) {
-      // Subscribe to global actions.
-      if (typeof action === "function" && listener === undefined) {
-        globalListeners.push(action);
-        return () => globalListeners.splice(globalListeners.indexOf(action), 1);
-      }
-
-      // Subscribe to specific actions.
-      else if (typeof action === "string" && listener) {
-        if (!actionListeners.has(action)) {
-          actionListeners.set(action, []);
-        }
-
-        actionListeners.get(action)?.push(listener);
-        return () => {
-          actionListeners
-            .get(action)
-            ?.splice(
-              actionListeners.get(action)?.indexOf(listener) as number,
-              1
-            );
-        };
-      } else {
-        throw new Error(
-          "MiniRdxError: Invalid arguments. Try: state.on(action: string, listener: ActionListener)"
-        );
-      }
-    },
-
-    ...apiActions,
+    actions: apiActions,
+    on: crereateListenr,
   };
 }
 

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,14 +1,20 @@
 import { useState, useEffect } from "react";
+import type { Store, Action } from "./index";
 
-export default function createStoreHooks(store: any) {
+export default function createStoreHooks<
+  S,
+  A extends Record<string, Action<S>>
+>(store: Store<S, A>) {
   const { state, on, actions } = store;
 
-  function useStore(selector?: any) {
+  function useStore<T = S>(
+    selector?: (state: S) => T
+  ): [T, Store<S, A>["actions"]] {
     const [data, setData] = useState(
       typeof selector === "function" ? selector(state()) : state()
     );
 
-    const updateSlice = (state: any) => {
+    const updateSlice = (state: S) => {
       const slice = typeof selector === "function" ? selector(state) : state;
       slice !== data && setData(slice);
     };
@@ -16,10 +22,10 @@ export default function createStoreHooks(store: any) {
     // Subscribe & unsubscribe to store.
     useEffect(() => on(updateSlice), [data]);
 
-    return [data, actions];
+    return [data as T, actions];
   }
 
-  function useStoreActions() {
+  function useStoreActions(): Store<S, A>["actions"] {
     return actions;
   }
 

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 
 export default function createStoreHooks(store: any) {
-  const { state, on, ...actions } = store;
+  const { state, on, actions } = store;
 
   function useStore(selector?: any) {
     const [data, setData] = useState(


### PR DESCRIPTION
1. Move all actions form `store` object under `store.actions` property for better readability 
2. Improve TS types definitions to provide better inference in React hooks